### PR TITLE
squid:S2974 - Classes without "public" constructors should be "final"

### DIFF
--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
@@ -14,7 +14,7 @@ import io.particle.android.sdk.cloud.ParticleCloudSDK;
 import io.particle.android.sdk.devicesetup.ui.GetReadyActivity;
 
 
-public class ParticleDeviceSetupLibrary {
+public final class ParticleDeviceSetupLibrary {
 
     /**
      * The contract for the broadcast sent upon device setup completion.

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/CommandClient.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/CommandClient.java
@@ -20,7 +20,7 @@ import okio.Okio;
 import static io.particle.android.sdk.utils.Py.truthy;
 
 
-public class CommandClient {
+public final class CommandClient {
 
     public static final int DEFAULT_TIMEOUT_SECONDS = 10;
 

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/ConfigureApCommand.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/ConfigureApCommand.java
@@ -12,7 +12,7 @@ import static io.particle.android.sdk.utils.Py.truthy;
  * Configure the access point details to connect to when connect-ap is called. The AP doesn't have
  * to be in the list from scan-ap, allowing manual entry of hidden networks.
  */
-public class ConfigureApCommand extends Command {
+public final class ConfigureApCommand extends Command {
 
     public final Integer idx;
 

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/setupsteps/StepConfig.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/setupsteps/StepConfig.java
@@ -2,7 +2,7 @@ package io.particle.android.sdk.devicesetup.setupsteps;
 
 import com.google.common.base.Preconditions;
 
-public class StepConfig {
+public final class StepConfig {
 
     public final int maxAttempts;
     public final int stepId;

--- a/devicesetup/src/main/java/io/particle/android/sdk/ui/NextActivitySelector.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/ui/NextActivitySelector.java
@@ -17,7 +17,7 @@ import static io.particle.android.sdk.utils.Py.truthy;
 /**
  * Selects the next Activity in the workflow, up to the "GetReady" screen or main UI.
  */
-public class NextActivitySelector {
+public final class NextActivitySelector {
 
     private static final TLog log = TLog.get(NextActivitySelector.class);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat