### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
@@ -15,6 +15,12 @@ import io.particle.android.sdk.devicesetup.ui.GetReadyActivity;
 
 
 public class ParticleDeviceSetupLibrary {
+    private static ParticleDeviceSetupLibrary instance;
+    private final Class<? extends Activity> mainActivity;
+
+    private ParticleDeviceSetupLibrary(Class<? extends Activity> mainActivity) {
+        this.mainActivity = mainActivity;
+    }
 
     /**
      * The contract for the broadcast sent upon device setup completion.
@@ -118,17 +124,8 @@ public class ParticleDeviceSetupLibrary {
         return instance;
     }
 
-    private static ParticleDeviceSetupLibrary instance;
-
-
     public Class<? extends Activity> getMainActivityClass() {
         return mainActivity;
-    }
-
-    private final Class<? extends Activity> mainActivity;
-
-    private ParticleDeviceSetupLibrary(Class<? extends Activity> mainActivity) {
-        this.mainActivity = mainActivity;
     }
 
 }

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/CommandClient.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/CommandClient.java
@@ -25,6 +25,17 @@ public class CommandClient {
     public static final int DEFAULT_TIMEOUT_SECONDS = 10;
 
 
+    private static final TLog log = TLog.get(CommandClient.class);
+    private static final Gson gson = new Gson();
+
+
+    private final InetSocketAddress deviceAddress;
+    
+    // no public constructor; use the factory methods above
+    private CommandClient(InetSocketAddress deviceAddress) {
+        this.deviceAddress = deviceAddress;
+    }
+
     public static CommandClient newClient(@NonNull InetSocketAddress socketAddress) {
         return new CommandClient(socketAddress);
     }
@@ -32,19 +43,6 @@ public class CommandClient {
     // FIXME: set these defaults in a resource file
     public static CommandClient newClientUsingDefaultSocketAddress() {
         return newClient(new InetSocketAddress("192.168.0.1", 5609));
-    }
-
-
-    private static final TLog log = TLog.get(CommandClient.class);
-    private static final Gson gson = new Gson();
-
-
-    private final InetSocketAddress deviceAddress;
-
-
-    // no public constructor; use the factory methods above
-    private CommandClient(InetSocketAddress deviceAddress) {
-        this.deviceAddress = deviceAddress;
     }
 
     public void sendCommand(Command command, CeciNestPasUnSocketFactory socketFactory) throws IOException {

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/ConfigureApCommand.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/ConfigureApCommand.java
@@ -27,15 +27,6 @@ public class ConfigureApCommand extends Command {
     @SerializedName("ch")
     public final Integer channel;
 
-    public static Builder newBuilder() {
-        return new Builder();
-    }
-
-    @Override
-    public String getCommandName() {
-        return "configure-ap";
-    }
-
     // private constructor -- use .newBuilder() instead.
     private ConfigureApCommand(int idx, String ssid, String encryptedPasswordHex,
                                WifiSecurity wifiSecurityType, int channel) {
@@ -46,6 +37,14 @@ public class ConfigureApCommand extends Command {
         this.channel = channel;
     }
 
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    @Override
+    public String getCommandName() {
+        return "configure-ap";
+    }
 
     public static class Response {
 

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/data/WifiSecurity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/commands/data/WifiSecurity.java
@@ -15,6 +15,7 @@ public enum WifiSecurity {
     WPA2_TKIP_PSK(0x00400002), // WPA2 Security with TKIP
     WPA2_MIXED_PSK(0x00400006); // WPA2 Security with AES & TKIP
 
+    private static final int ENTERPRISE_ENABLED_MASK = 0x02000000;
 
     static final ImmutableMap<Integer, WifiSecurity> fromIntMap;
 
@@ -38,8 +39,6 @@ public enum WifiSecurity {
     WifiSecurity(int intValue) {
         this.intValue = intValue;
     }
-
-    private static final int ENTERPRISE_ENABLED_MASK = 0x02000000;
 
     // FIXME: accommodate this better
     public static boolean isEnterpriseNetwork(int value) {

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/loaders/WifiScanResultLoader.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/loaders/WifiScanResultLoader.java
@@ -6,20 +6,18 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiManager;
-
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import io.particle.android.sdk.devicesetup.R;
 import io.particle.android.sdk.devicesetup.model.ScanResultNetwork;
 import io.particle.android.sdk.utils.BetterAsyncTaskLoader;
 import io.particle.android.sdk.utils.TLog;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 
 public class WifiScanResultLoader extends BetterAsyncTaskLoader<Set<ScanResultNetwork>> {
@@ -32,6 +30,29 @@ public class WifiScanResultLoader extends BetterAsyncTaskLoader<Set<ScanResultNe
 
     private volatile ImmutableSet<ScanResultNetwork> mostRecentResult;
     private volatile int loadCount = 0;
+
+    private final Predicate<ScanResult> ssidStartsWithProductName = new Predicate<ScanResult>() {
+
+        final String softApPrefix = getPrefix();
+
+        @Override
+        public boolean apply(ScanResult input) {
+            return input.SSID != null && input.SSID.toLowerCase().startsWith(softApPrefix);
+        }
+
+        String getPrefix() {
+            return (getContext().getString(R.string.network_name_prefix)+ "-").toLowerCase();
+        }
+
+    };
+
+    private static final Function<ScanResult, ScanResultNetwork> toWifiNetwork =
+            new Function<ScanResult, ScanResultNetwork>() {
+                @Override
+                public ScanResultNetwork apply(ScanResult input) {
+                    return new ScanResultNetwork(input);
+                }
+            };
 
     public WifiScanResultLoader(Context context) {
         super(context);
@@ -103,30 +124,5 @@ public class WifiScanResultLoader extends BetterAsyncTaskLoader<Set<ScanResultNe
             return new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION);
         }
     }
-
-
-    private final Predicate<ScanResult> ssidStartsWithProductName = new Predicate<ScanResult>() {
-
-        final String softApPrefix = getPrefix();
-
-        @Override
-        public boolean apply(ScanResult input) {
-            return input.SSID != null && input.SSID.toLowerCase().startsWith(softApPrefix);
-        }
-
-        String getPrefix() {
-            return (getContext().getString(R.string.network_name_prefix)+ "-").toLowerCase();
-        }
-
-    };
-
-
-    private static final Function<ScanResult, ScanResultNetwork> toWifiNetwork =
-            new Function<ScanResult, ScanResultNetwork>() {
-        @Override
-        public ScanResultNetwork apply(ScanResult input) {
-            return new ScanResultNetwork(input);
-        }
-    };
 
 }

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/setupsteps/EnsureSoftApNotVisible.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/setupsteps/EnsureSoftApNotVisible.java
@@ -23,6 +23,13 @@ public class EnsureSoftApNotVisible extends SetupStep {
 
     private boolean wasFulfilledOnce = false;
 
+    private static final Function<ScanResult, String> toSSID = new Function<ScanResult, String>() {
+        @Override
+        public String apply(ScanResult input) {
+            return (input == null) ? null : input.SSID;
+        }
+    };
+
     public EnsureSoftApNotVisible(StepConfig stepConfig, String softApSSID, Context ctx) {
         super(stepConfig);
 
@@ -96,11 +103,4 @@ public class EnsureSoftApNotVisible extends SetupStep {
         return matchingSSID.isPresent();
     }
 
-
-    private static final Function<ScanResult, String> toSSID = new Function<ScanResult, String>() {
-        @Override
-        public String apply(ScanResult input) {
-            return (input == null) ? null : input.SSID;
-        }
-    };
 }

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/ConnectToApFragment.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/ConnectToApFragment.java
@@ -41,6 +41,20 @@ public class ConnectToApFragment extends WorkerFragment {
 
     public static final String TAG = WorkerFragment.buildFragmentTag(ConnectToApFragment.class);
 
+    private static final TLog log = TLog.get(ConnectToApFragment.class);
+
+
+    private WifiManager wifiManager;
+    private BroadcastReceiver wifiStateChangeListener;
+    private WifiStateChangeLogger wifiStateChangeLogger;
+    private Context appContext;
+    private ClientDecorator client;
+    private SoftAPConfigRemover softAPConfigRemover;
+
+    // for handling through the runloop
+    private Handler mainThreadHandler;
+    private Runnable onTimeoutRunnable;
+    private final List<Runnable> setupRunnables = list();
 
     public static ConnectToApFragment get(FragmentActivity activity) {
         return Ui.findFrag(activity, TAG);
@@ -64,22 +78,6 @@ public class ConnectToApFragment extends WorkerFragment {
         config.priority = 999999;
         return config;
     }
-
-
-    private static final TLog log = TLog.get(ConnectToApFragment.class);
-
-
-    private WifiManager wifiManager;
-    private BroadcastReceiver wifiStateChangeListener;
-    private WifiStateChangeLogger wifiStateChangeLogger;
-    private Context appContext;
-    private ClientDecorator client;
-    private SoftAPConfigRemover softAPConfigRemover;
-
-    // for handling through the runloop
-    private Handler mainThreadHandler;
-    private Runnable onTimeoutRunnable;
-    private final List<Runnable> setupRunnables = list();
 
     @Override
     public void onAttach(Activity activity) {

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/ConnectingActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/ConnectingActivity.java
@@ -60,21 +60,6 @@ public class ConnectingActivity extends RequiresWifiScansActivity {
     private static final TLog log = TLog.get(ConnectingActivity.class);
     private static final Gson gson = new Gson();
 
-    public static Intent buildIntent(Context ctx, String deviceSoftApSsid,
-                                     ScanApCommand.Scan networkToConnectTo) {
-        return new Intent(ctx, ConnectingActivity.class)
-                .putExtra(EXTRA_NETWORK_TO_CONFIGURE, gson.toJson(networkToConnectTo))
-                .putExtra(EXTRA_SOFT_AP_SSID, deviceSoftApSsid);
-    }
-
-
-    public static Intent buildIntent(Context ctx, String deviceSoftApSsid,
-                                     ScanApCommand.Scan networkToConnectTo, String secret) {
-        return buildIntent(ctx, deviceSoftApSsid, networkToConnectTo)
-                .putExtra(EXTRA_NETWORK_SECRET, secret);
-    }
-
-
     // FIXME: all this state needs to be configured and encapsulated better
     private CommandClient client;
     private ConnectingProcessWorkerTask connectingProcessWorkerTask;
@@ -91,6 +76,19 @@ public class ConnectingActivity extends RequiresWifiScansActivity {
     private Drawable tintedSpinner;
     private Drawable tintedCheckmark;
 
+    public static Intent buildIntent(Context ctx, String deviceSoftApSsid,
+                                     ScanApCommand.Scan networkToConnectTo) {
+        return new Intent(ctx, ConnectingActivity.class)
+                .putExtra(EXTRA_NETWORK_TO_CONFIGURE, gson.toJson(networkToConnectTo))
+                .putExtra(EXTRA_SOFT_AP_SSID, deviceSoftApSsid);
+    }
+
+
+    public static Intent buildIntent(Context ctx, String deviceSoftApSsid,
+                                     ScanApCommand.Scan networkToConnectTo, String secret) {
+        return buildIntent(ctx, deviceSoftApSsid, networkToConnectTo)
+                .putExtra(EXTRA_NETWORK_SECRET, secret);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/PasswordEntryActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/PasswordEntryActivity.java
@@ -24,6 +24,12 @@ import io.particle.android.sdk.utils.ui.Ui;
 // FIXME: password validation -- check for correct length based on security type?
 // at least check for minimum.
 public class PasswordEntryActivity extends BaseActivity {
+    private static final TLog log = TLog.get(PasswordEntryActivity.class);
+    private static final Gson gson = new Gson();
+
+    private CheckBox showPwdBox;
+    private EditText passwordBox;
+    private ScanApCommand.Scan networkToConnectTo;
 
     public static final String EXTRA_NETWORK_TO_CONFIGURE = "EXTRA_NETWORK_TO_CONFIGURE";
 
@@ -31,14 +37,6 @@ public class PasswordEntryActivity extends BaseActivity {
         return new Intent(ctx, PasswordEntryActivity.class)
                 .putExtra(EXTRA_NETWORK_TO_CONFIGURE, gson.toJson(networkToConnectTo));
     }
-
-
-    private static final TLog log = TLog.get(PasswordEntryActivity.class);
-    private static final Gson gson = new Gson();
-
-    private CheckBox showPwdBox;
-    private EditText passwordBox;
-    private ScanApCommand.Scan networkToConnectTo;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/PermissionsFragment.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/PermissionsFragment.java
@@ -30,6 +30,11 @@ import static io.particle.android.sdk.utils.Py.set;
 
 public class PermissionsFragment extends Fragment implements OnRequestPermissionsResultCallback {
 
+    private static final int REQUEST_CODE = 128;
+
+    private static final String PREF_BUCKET_NAME = "permissionsFragmentPrefs";
+    private static final String PREF_KEY_PERMISSION_DIALOGS_SHOWN = "permissionsDialogsShown";
+
     public interface Client {
         void onUserAllowedPermission(String permission);
 
@@ -136,11 +141,6 @@ public class PermissionsFragment extends Fragment implements OnRequestPermission
                 new String[]{permission},
                 REQUEST_CODE);
     }
-
-    private static final int REQUEST_CODE = 128;
-
-    private static final String PREF_BUCKET_NAME = "permissionsFragmentPrefs";
-    private static final String PREF_KEY_PERMISSION_DIALOGS_SHOWN = "permissionsDialogsShown";
 
     private static boolean haveShownPermissionDialog(Context ctx, String permission) {
         SharedPreferences prefs = ctx.getSharedPreferences(PREF_BUCKET_NAME, Context.MODE_PRIVATE);

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/SuccessActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/SuccessActivity.java
@@ -35,13 +35,13 @@ public class SuccessActivity extends BaseActivity {
     public static final int RESULT_FAILURE_NO_DISCONNECT = 5;
     public static final int RESULT_FAILURE_LOST_CONNECTION_TO_DEVICE = 6;
 
+    private static final SparseArray<Pair<Integer, Integer>> resultCodesToStringIds;
+    private ParticleCloud particleCloud;
 
     public static Intent buildIntent(Context ctx, int resultCode) {
         return new Intent(ctx, SuccessActivity.class)
                 .putExtra(EXTRA_RESULT_CODE, resultCode);
     }
-
-    private static final SparseArray<Pair<Integer, Integer>> resultCodesToStringIds;
 
     static {
         resultCodesToStringIds = new SparseArray<>(6);
@@ -69,8 +69,6 @@ public class SuccessActivity extends BaseActivity {
                 R.string.setup_failure_configure_summary,
                 R.string.setup_failure_lost_connection_to_device));
     }
-
-    private ParticleCloud particleCloud;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/devicesetup/src/main/java/io/particle/android/sdk/ui/NextActivitySelector.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/ui/NextActivitySelector.java
@@ -21,17 +21,6 @@ public class NextActivitySelector {
 
     private static final TLog log = TLog.get(NextActivitySelector.class);
 
-
-    public static Intent getNextActivityIntent(Context ctx, ParticleCloud particleCloud,
-                                               SensitiveDataStorage credStorage) {
-        NextActivitySelector selector = new NextActivitySelector(particleCloud, credStorage,
-                ParticleDeviceSetupLibrary.getInstance().getMainActivityClass());
-
-        Class <? extends Activity> nextActivity = selector.buildIntentForNextActivity();
-        return new Intent(ctx, nextActivity);
-    }
-
-
     private final ParticleCloud cloud;
     private final SensitiveDataStorage credStorage;
     private final Class<? extends Activity> mainActivityClass;
@@ -44,6 +33,14 @@ public class NextActivitySelector {
         this.mainActivityClass = mainActivityClass;
     }
 
+    public static Intent getNextActivityIntent(Context ctx, ParticleCloud particleCloud,
+                                               SensitiveDataStorage credStorage) {
+        NextActivitySelector selector = new NextActivitySelector(particleCloud, credStorage,
+                ParticleDeviceSetupLibrary.getInstance().getMainActivityClass());
+
+        Class <? extends Activity> nextActivity = selector.buildIntentForNextActivity();
+        return new Intent(ctx, nextActivity);
+    }
 
     Class<? extends Activity> buildIntentForNextActivity() {
         if (!hasUserBeenLoggedInBefore()) {

--- a/devicesetup/src/main/java/io/particle/android/sdk/utils/BetterAsyncTaskLoader.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/utils/BetterAsyncTaskLoader.java
@@ -6,15 +6,13 @@ import android.support.v4.content.AsyncTaskLoader;
 
 public abstract class BetterAsyncTaskLoader<T> extends AsyncTaskLoader<T> {
 
+    public BetterAsyncTaskLoader(Context context) {
+        super(context);
+    }
 
     public abstract boolean hasContent();
 
     public abstract T getLoadedContent();
-
-
-    public BetterAsyncTaskLoader(Context context) {
-        super(context);
-    }
 
     @Override
     protected void onStartLoading() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat