### PR TITLE
Rework 'setup complete' handling to allow users to create a custom Intent.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.3.1'

--- a/devicesetup/src/main/java/io/particle/android/sdk/accountsetup/CreateAccountActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/accountsetup/CreateAccountActivity.java
@@ -228,7 +228,8 @@ public class CreateAccountActivity extends BaseActivity {
         startActivity(NextActivitySelector.getNextActivityIntent(
                 CreateAccountActivity.this,
                 cloud,
-                SDKGlobals.getSensitiveDataStorage()));
+                SDKGlobals.getSensitiveDataStorage(),
+                null));
         finish();
     }
 

--- a/devicesetup/src/main/java/io/particle/android/sdk/accountsetup/LoginActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/accountsetup/LoginActivity.java
@@ -200,7 +200,8 @@ public class LoginActivity extends BaseActivity {
                     startActivity(NextActivitySelector.getNextActivityIntent(
                             LoginActivity.this,
                             sparkCloud,
-                            SDKGlobals.getSensitiveDataStorage()));
+                            SDKGlobals.getSensitiveDataStorage(),
+                            null));
                     finish();
                 }
 

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
@@ -89,6 +89,7 @@ public class ParticleDeviceSetupLibrary {
      * @deprecated Use {@link ParticleDeviceSetupLibrary#startDeviceSetup(Context, Class)}
      *             or {@link ParticleDeviceSetupLibrary#startDeviceSetup(Context, SetupCompleteIntentBuilder)} instead.
      */
+    @Deprecated
     public static void startDeviceSetup(Context ctx) {
         Preconditions.checkNotNull(instance.setupCompleteIntentBuilder,
                 "SetupCompleteIntentBuilder instance is null");

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
@@ -167,6 +167,12 @@ public class ParticleDeviceSetupLibrary {
 
     private SetupCompleteIntentBuilder setupCompleteIntentBuilder;
 
+    /**
+     * @deprecated This exists only because {@link io.particle.android.sdk.ui.NextActivitySelector}
+     * is in a different package, and the plan is to remove that class soon.
+     * As soon as {@link io.particle.android.sdk.ui.NextActivitySelector} is removed, this will be removed.
+     */
+    @Deprecated
     public SetupCompleteIntentBuilder getSetupCompleteIntentBuilder() {
         return setupCompleteIntentBuilder;
     }

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
@@ -26,14 +26,10 @@ public class ParticleDeviceSetupLibrary {
      */
     public interface DeviceSetupCompleteContract {
 
-        /**
-         * The BroadcastIntent action sent when the device setup process is complete.
-         */
+        /** The BroadcastIntent action sent when the device setup process is complete. */
         String ACTION_DEVICE_SETUP_COMPLETE = "ACTION_DEVICE_SETUP_COMPLETE";
 
-        /**
-         * A boolean extra indicating if the setup was successful
-         */
+        /** A boolean extra indicating if the setup was successful */
         String EXTRA_DEVICE_SETUP_WAS_SUCCESSFUL = "EXTRA_DEVICE_SETUP_WAS_SUCCESSFUL";
 
         /**
@@ -59,16 +55,12 @@ public class ParticleDeviceSetupLibrary {
         public abstract void onSetupFailure();
 
 
-        /**
-         * Optional convenience method for registering this receiver.
-         */
+        /** Optional convenience method for registering this receiver. */
         public void register(Context ctx) {
             LocalBroadcastManager.getInstance(ctx).registerReceiver(this, buildIntentFilter());
         }
 
-        /**
-         * Optional convenience method for registering this receiver.
-         */
+        /** Optional convenience method for registering this receiver. */
         public void unregister(Context ctx) {
             LocalBroadcastManager.getInstance(ctx).unregisterReceiver(this);
         }

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
@@ -98,7 +98,7 @@ public class ParticleDeviceSetupLibrary {
     }
 
     public static void startDeviceSetup(Context ctx, SetupCompleteIntentBuilder setupCompleteIntentBuilder) {
-        instance.setSetupCompleteIntentBuilder(setupCompleteIntentBuilder);
+        instance.setupCompleteIntentBuilder = setupCompleteIntentBuilder;
 
         startDeviceSetup(ctx);
     }
@@ -134,12 +134,12 @@ public class ParticleDeviceSetupLibrary {
     public static void init(Context ctx, final Class<? extends Activity> mainActivity) {
         init(ctx);
 
-        instance.setSetupCompleteIntentBuilder(new SetupCompleteIntentBuilder() {
+        instance.setupCompleteIntentBuilder = new SetupCompleteIntentBuilder() {
             @Override
             public Intent buildIntent(Context ctx, SetupResult result) {
                 return new Intent(ctx, mainActivity);
             }
-        });
+        };
     }
 
     /**
@@ -169,10 +169,6 @@ public class ParticleDeviceSetupLibrary {
 
     public SetupCompleteIntentBuilder getSetupCompleteIntentBuilder() {
         return setupCompleteIntentBuilder;
-    }
-
-    public void setSetupCompleteIntentBuilder(SetupCompleteIntentBuilder setupCompleteIntentBuilder) {
-        this.setupCompleteIntentBuilder = setupCompleteIntentBuilder;
     }
 
     private ParticleDeviceSetupLibrary() {

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/SetupCompleteIntentBuilder.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/SetupCompleteIntentBuilder.java
@@ -2,7 +2,8 @@ package io.particle.android.sdk.devicesetup;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.Nullable;
 
 public interface SetupCompleteIntentBuilder {
-    Intent buildIntent(Context ctx, SetupResult result);
+    Intent buildIntent(Context ctx, @Nullable SetupResult result);
 }

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/SetupCompleteIntentBuilder.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/SetupCompleteIntentBuilder.java
@@ -1,0 +1,8 @@
+package io.particle.android.sdk.devicesetup;
+
+import android.content.Context;
+import android.content.Intent;
+
+public interface SetupCompleteIntentBuilder {
+    Intent buildIntent(Context ctx, SetupResult result);
+}

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/SetupResult.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/SetupResult.java
@@ -1,0 +1,27 @@
+package io.particle.android.sdk.devicesetup;
+
+public class SetupResult {
+    private boolean wasSuccessful;
+    private String configuredDeviceId;
+
+    public SetupResult(boolean wasSuccessful, String configuredDeviceId) {
+        this.wasSuccessful = wasSuccessful;
+        this.configuredDeviceId = configuredDeviceId;
+    }
+
+    public boolean wasSuccessful() {
+        return wasSuccessful;
+    }
+
+    public void setWasSuccessful(boolean wasSuccessful) {
+        this.wasSuccessful = wasSuccessful;
+    }
+
+    public String getConfiguredDeviceId() {
+        return configuredDeviceId;
+    }
+
+    public void setConfiguredDeviceId(String configuredDeviceId) {
+        this.configuredDeviceId = configuredDeviceId;
+    }
+}

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/SetupResult.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/SetupResult.java
@@ -1,8 +1,11 @@
 package io.particle.android.sdk.devicesetup;
 
-public class SetupResult {
-    private boolean wasSuccessful;
-    private String configuredDeviceId;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class SetupResult implements Parcelable {
+    private final boolean wasSuccessful;
+    private final String configuredDeviceId;
 
     public SetupResult(boolean wasSuccessful, String configuredDeviceId) {
         this.wasSuccessful = wasSuccessful;
@@ -13,15 +16,35 @@ public class SetupResult {
         return wasSuccessful;
     }
 
-    public void setWasSuccessful(boolean wasSuccessful) {
-        this.wasSuccessful = wasSuccessful;
-    }
-
     public String getConfiguredDeviceId() {
         return configuredDeviceId;
     }
 
-    public void setConfiguredDeviceId(String configuredDeviceId) {
-        this.configuredDeviceId = configuredDeviceId;
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(wasSuccessful ? 1 : 0);
+        dest.writeString(configuredDeviceId);
+    }
+
+    public static final Parcelable.Creator<SetupResult> CREATOR = new Parcelable.Creator<SetupResult>() {
+        @Override
+        public SetupResult createFromParcel(Parcel source) {
+            return new SetupResult(source);
+        }
+
+        @Override
+        public SetupResult[] newArray(int size) {
+            return new SetupResult[size];
+        }
+    };
+
+    private SetupResult(Parcel source) {
+        wasSuccessful = source.readInt() == 1;
+        configuredDeviceId = source.readString();
     }
 }

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/SuccessActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/SuccessActivity.java
@@ -16,6 +16,7 @@ import io.particle.android.sdk.cloud.SDKGlobals;
 import io.particle.android.sdk.cloud.ParticleCloud;
 import io.particle.android.sdk.devicesetup.ParticleDeviceSetupLibrary;
 import io.particle.android.sdk.devicesetup.R;
+import io.particle.android.sdk.devicesetup.SetupResult;
 import io.particle.android.sdk.ui.BaseActivity;
 import io.particle.android.sdk.ui.NextActivitySelector;
 import io.particle.android.sdk.utils.ui.Ui;
@@ -97,7 +98,8 @@ public class SuccessActivity extends BaseActivity {
                 Intent intent = NextActivitySelector.getNextActivityIntent(
                         v.getContext(),
                         particleCloud,
-                        SDKGlobals.getSensitiveDataStorage());
+                        SDKGlobals.getSensitiveDataStorage(),
+                        new SetupResult(isSuccess, isSuccess ? DeviceSetupState.deviceToBeSetUpId : null));
 
                 // FIXME: we shouldn't do this in the lib.  looks like another argument for Fragments.
                 intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP

--- a/devicesetup/src/main/java/io/particle/android/sdk/ui/NextActivitySelector.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/ui/NextActivitySelector.java
@@ -4,10 +4,14 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
+import com.google.common.base.Preconditions;
+
 import io.particle.android.sdk.accountsetup.CreateAccountActivity;
 import io.particle.android.sdk.accountsetup.LoginActivity;
 import io.particle.android.sdk.cloud.ParticleCloud;
 import io.particle.android.sdk.devicesetup.ParticleDeviceSetupLibrary;
+import io.particle.android.sdk.devicesetup.SetupCompleteIntentBuilder;
+import io.particle.android.sdk.devicesetup.SetupResult;
 import io.particle.android.sdk.persistance.SensitiveDataStorage;
 import io.particle.android.sdk.utils.TLog;
 
@@ -22,42 +26,47 @@ public class NextActivitySelector {
     private static final TLog log = TLog.get(NextActivitySelector.class);
 
 
-    public static Intent getNextActivityIntent(Context ctx, ParticleCloud particleCloud,
-                                               SensitiveDataStorage credStorage) {
+    public static Intent getNextActivityIntent(Context ctx,
+                                               ParticleCloud particleCloud,
+                                               SensitiveDataStorage credStorage,
+                                               SetupResult setupResult) {
         NextActivitySelector selector = new NextActivitySelector(particleCloud, credStorage,
-                ParticleDeviceSetupLibrary.getInstance().getMainActivityClass());
+                ParticleDeviceSetupLibrary.getInstance().getSetupCompleteIntentBuilder());
 
-        Class <? extends Activity> nextActivity = selector.buildIntentForNextActivity();
-        return new Intent(ctx, nextActivity);
+        return selector.buildIntentForNextActivity(ctx, setupResult);
     }
 
 
     private final ParticleCloud cloud;
     private final SensitiveDataStorage credStorage;
-    private final Class<? extends Activity> mainActivityClass;
+    private final SetupCompleteIntentBuilder setupCompleteIntentBuilder;
 
     private NextActivitySelector(ParticleCloud cloud,
                                  SensitiveDataStorage credStorage,
-                                 Class<? extends Activity> mainActivityClass) {
+                                 SetupCompleteIntentBuilder setupCompleteIntentBuilder) {
+        Preconditions.checkNotNull(setupCompleteIntentBuilder, "SetupCompleteIntentBuilder instance is null");
+
         this.cloud = cloud;
         this.credStorage = credStorage;
-        this.mainActivityClass = mainActivityClass;
+        this.setupCompleteIntentBuilder = setupCompleteIntentBuilder;
     }
 
-
-    Class<? extends Activity> buildIntentForNextActivity() {
+    Intent buildIntentForNextActivity(Context ctx, SetupResult result) {
         if (!hasUserBeenLoggedInBefore()) {
             log.d("User has not been logged in before");
-            return CreateAccountActivity.class;
+            return new Intent(ctx, CreateAccountActivity.class);
         }
 
         if (!isOAuthTokenPresent()) {
             log.d("No auth token present");
-            return LoginActivity.class;
+            return new Intent(ctx, LoginActivity.class);
         }
 
-        log.d("Returning default activity");
-        return mainActivityClass;
+        log.d("Building setup complete activity...");
+        Intent successActivity = setupCompleteIntentBuilder.buildIntent(ctx, result);
+
+        log.d("Returning setup complete activity");
+        return successActivity;
     }
 
     boolean hasUserBeenLoggedInBefore() {

--- a/exampleapp/src/main/java/io/particle/devicesetup/exampleapp/ExampleSetupCompleteIntentBuilder.java
+++ b/exampleapp/src/main/java/io/particle/devicesetup/exampleapp/ExampleSetupCompleteIntentBuilder.java
@@ -1,0 +1,23 @@
+package io.particle.devicesetup.exampleapp;
+
+import android.content.Context;
+import android.content.Intent;
+
+import io.particle.android.sdk.devicesetup.SetupCompleteIntentBuilder;
+import io.particle.android.sdk.devicesetup.SetupResult;
+
+public class ExampleSetupCompleteIntentBuilder implements SetupCompleteIntentBuilder {
+    private final String setupLaunchedTime;
+
+    public ExampleSetupCompleteIntentBuilder(String setupLaunchedTime) {
+        this.setupLaunchedTime = setupLaunchedTime;
+    }
+
+    @Override
+    public Intent buildIntent(Context ctx, SetupResult result) {
+        Intent intent = new Intent(ctx, MainActivity.class);
+        intent.putExtra(MainActivity.EXTRA_SETUP_LAUNCHED_TIME, setupLaunchedTime);
+
+        return intent;
+    }
+}

--- a/exampleapp/src/main/java/io/particle/devicesetup/exampleapp/MainActivity.java
+++ b/exampleapp/src/main/java/io/particle/devicesetup/exampleapp/MainActivity.java
@@ -1,7 +1,5 @@
 package io.particle.devicesetup.exampleapp;
 
-import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -10,12 +8,10 @@ import android.widget.TextView;
 import java.util.Date;
 
 import io.particle.android.sdk.devicesetup.ParticleDeviceSetupLibrary;
-import io.particle.android.sdk.devicesetup.SetupCompleteIntentBuilder;
-import io.particle.android.sdk.devicesetup.SetupResult;
 import io.particle.android.sdk.utils.ui.Ui;
 
 public class MainActivity extends AppCompatActivity {
-    private final static String EXTRA_SETUP_LAUNCHED_TIME = "io.particle.devicesetup.exampleapp.SETUP_LAUNCHED_TIME";
+    public final static String EXTRA_SETUP_LAUNCHED_TIME = "io.particle.devicesetup.exampleapp.SETUP_LAUNCHED_TIME";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,15 +49,8 @@ public class MainActivity extends AppCompatActivity {
     private void invokeDeviceSetupWithCustomIntentBuilder() {
         final String setupLaunchedTime = new Date().toString();
 
-        ParticleDeviceSetupLibrary.startDeviceSetup(this, new SetupCompleteIntentBuilder() {
-            @Override
-            public Intent buildIntent(Context ctx, SetupResult result) {
-                Intent intent = new Intent(ctx, MainActivity.class);
-                intent.putExtra(EXTRA_SETUP_LAUNCHED_TIME, setupLaunchedTime);
-
-                return intent;
-            }
-        });
-
+        // Important: don't use an anonymous inner class to implement SetupCompleteIntentBuilder, otherwise you will cause a memory leak.
+        ParticleDeviceSetupLibrary.startDeviceSetup(this, new ExampleSetupCompleteIntentBuilder(setupLaunchedTime));
     }
+
 }

--- a/exampleapp/src/main/java/io/particle/devicesetup/exampleapp/MainActivity.java
+++ b/exampleapp/src/main/java/io/particle/devicesetup/exampleapp/MainActivity.java
@@ -1,19 +1,27 @@
 package io.particle.devicesetup.exampleapp;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+import android.widget.TextView;
+
+import java.util.Date;
 
 import io.particle.android.sdk.devicesetup.ParticleDeviceSetupLibrary;
+import io.particle.android.sdk.devicesetup.SetupCompleteIntentBuilder;
+import io.particle.android.sdk.devicesetup.SetupResult;
 import io.particle.android.sdk.utils.ui.Ui;
 
 public class MainActivity extends AppCompatActivity {
+    private final static String EXTRA_SETUP_LAUNCHED_TIME = "io.particle.devicesetup.exampleapp.SETUP_LAUNCHED_TIME";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        ParticleDeviceSetupLibrary.init(this.getApplicationContext(), MainActivity.class);
+        ParticleDeviceSetupLibrary.init(this.getApplicationContext());
 
         Ui.findView(this, R.id.start_setup_button).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -21,9 +29,39 @@ public class MainActivity extends AppCompatActivity {
                 invokeDeviceSetup();
             }
         });
+
+        Ui.findView(this, R.id.start_setup_custom_intent_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                invokeDeviceSetupWithCustomIntentBuilder();
+            }
+        });
+
+        String setupLaunchTime = this.getIntent().getStringExtra(EXTRA_SETUP_LAUNCHED_TIME);
+
+        if (setupLaunchTime != null) {
+            TextView label = Ui.findView(this, R.id.textView);
+
+            label.setText(String.format(getString(R.string.welcome_back), setupLaunchTime));
+        }
     }
 
     public void invokeDeviceSetup() {
-        ParticleDeviceSetupLibrary.startDeviceSetup(this);
+        ParticleDeviceSetupLibrary.startDeviceSetup(this, MainActivity.class);
+    }
+
+    private void invokeDeviceSetupWithCustomIntentBuilder() {
+        final String setupLaunchedTime = new Date().toString();
+
+        ParticleDeviceSetupLibrary.startDeviceSetup(this, new SetupCompleteIntentBuilder() {
+            @Override
+            public Intent buildIntent(Context ctx, SetupResult result) {
+                Intent intent = new Intent(ctx, MainActivity.class);
+                intent.putExtra(EXTRA_SETUP_LAUNCHED_TIME, setupLaunchedTime);
+
+                return intent;
+            }
+        });
+
     }
 }

--- a/exampleapp/src/main/res/layout/activity_main.xml
+++ b/exampleapp/src/main/res/layout/activity_main.xml
@@ -22,4 +22,13 @@
         android:layout_marginTop="76dp"
         android:text="Start Setup"/>
 
+    <Button
+        android:id="@+id/start_setup_custom_intent_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Start Setup with Custom Intent Builder"
+        android:layout_below="@+id/start_setup_button"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"/>
+
 </RelativeLayout>

--- a/exampleapp/src/main/res/values/strings.xml
+++ b/exampleapp/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
     <string name="app_name">Example app</string>
 
     <string name="hello_world">Hello world!</string>
+    <string name="welcome_back">Welcome back! You\'ve returned from setup, which started at %s.</string>
+
     <string name="action_settings">Settings</string>
 
     <!-- Enable full logging in the cloud SDK -->


### PR DESCRIPTION
Notes:
* I've marked a couple of methods in `ParticleDeviceSetupLibrary` as deprecated. These should be removed completely at some point in the future.
* This change probably removes the need for the broadcast when device setup is complete, but I haven't removed it yet to avoid breaking users who currently rely on it.