### PR TITLE
Crash fix in WifiFacade

### DIFF
--- a/devicesetup/src/main/java/io/particle/android/sdk/utils/WifiFacade.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/utils/WifiFacade.java
@@ -115,6 +115,9 @@ public class WifiFacade {
                 Arrays.asList(connectivityManager.getAllNetworks()),
                 network -> {
                     NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
+                    if (!Py.truthy(networkInfo.getExtraInfo())) {
+                        return false;
+                    }
                     return SSID.from(networkInfo.getExtraInfo()).equals(ssid);
                 }
         );


### PR DESCRIPTION
Hidden networks will have a falsey `.getExtraInfo()` return value, which will cause `SSID.from()` to fail.  Fixes the crash found by the temporary Crashlytics-enabled build.